### PR TITLE
Implement the web UI for Mirage

### DIFF
--- a/services/web-ui/Cargo.toml
+++ b/services/web-ui/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "web-ui"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+actix-web = "4.0"
+serde = { version = "1.0", features = ["derive"] }
+uuid = { version = "0.8", features = ["v4"] }
+log = "0.4"
+env_logger = "0.9"

--- a/services/web-ui/src/main.rs
+++ b/services/web-ui/src/main.rs
@@ -3,6 +3,7 @@ use actix_web::middleware::Logger;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 use uuid::Uuid;
+use log::{info, warn, error}; // P1372
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Scan {
@@ -23,6 +24,7 @@ async fn create_scan(scan: web::Json<Scan>, db: web::Data<ScanDb>) -> impl Respo
         ..scan.into_inner()
     };
     scans.push(new_scan.clone());
+    info!("Created new scan: {:?}", new_scan); // P1372
     HttpResponse::Ok().json(new_scan)
 }
 
@@ -30,8 +32,10 @@ async fn create_scan(scan: web::Json<Scan>, db: web::Data<ScanDb>) -> impl Respo
 async fn get_scan(id: web::Path<Uuid>, db: web::Data<ScanDb>) -> impl Responder {
     let scans = db.lock().unwrap();
     if let Some(scan) = scans.iter().find(|&scan| scan.id == *id) {
+        info!("Fetched scan: {:?}", scan); // P1372
         HttpResponse::Ok().json(scan)
     } else {
+        warn!("Scan not found: {:?}", id); // P1372
         HttpResponse::NotFound().finish()
     }
 }
@@ -41,8 +45,10 @@ async fn update_scan(id: web::Path<Uuid>, scan: web::Json<Scan>, db: web::Data<S
     let mut scans = db.lock().unwrap();
     if let Some(existing_scan) = scans.iter_mut().find(|scan| scan.id == *id) {
         *existing_scan = scan.into_inner();
+        info!("Updated scan: {:?}", existing_scan); // P1372
         HttpResponse::Ok().json(existing_scan.clone())
     } else {
+        warn!("Scan not found: {:?}", id); // P1372
         HttpResponse::NotFound().finish()
     }
 }
@@ -52,8 +58,10 @@ async fn delete_scan(id: web::Path<Uuid>, db: web::Data<ScanDb>) -> impl Respond
     let mut scans = db.lock().unwrap();
     if let Some(pos) = scans.iter().position(|scan| scan.id == *id) {
         scans.remove(pos);
+        info!("Deleted scan: {:?}", id); // P1372
         HttpResponse::NoContent().finish()
     } else {
+        warn!("Scan not found: {:?}", id); // P1372
         HttpResponse::NotFound().finish()
     }
 }
@@ -61,6 +69,7 @@ async fn delete_scan(id: web::Path<Uuid>, db: web::Data<ScanDb>) -> impl Respond
 #[get("/scans")]
 async fn list_scans(db: web::Data<ScanDb>) -> impl Responder {
     let scans = db.lock().unwrap();
+    info!("Listing all scans"); // P1372
     HttpResponse::Ok().json(scans.clone())
 }
 
@@ -83,6 +92,7 @@ async fn create_event(event: web::Json<Event>, db: web::Data<EventDb>) -> impl R
         ..event.into_inner()
     };
     events.push(new_event.clone());
+    info!("Created new event: {:?}", new_event); // P1372
     HttpResponse::Ok().json(new_event)
 }
 
@@ -90,8 +100,10 @@ async fn create_event(event: web::Json<Event>, db: web::Data<EventDb>) -> impl R
 async fn get_event(id: web::Path<Uuid>, db: web::Data<EventDb>) -> impl Responder {
     let events = db.lock().unwrap();
     if let Some(event) = events.iter().find(|&event| event.id == *id) {
+        info!("Fetched event: {:?}", event); // P1372
         HttpResponse::Ok().json(event)
     } else {
+        warn!("Event not found: {:?}", id); // P1372
         HttpResponse::NotFound().finish()
     }
 }
@@ -101,8 +113,10 @@ async fn update_event(id: web::Path<Uuid>, event: web::Json<Event>, db: web::Dat
     let mut events = db.lock().unwrap();
     if let Some(existing_event) = events.iter_mut().find(|event| event.id == *id) {
         *existing_event = event.into_inner();
+        info!("Updated event: {:?}", existing_event); // P1372
         HttpResponse::Ok().json(existing_event.clone())
     } else {
+        warn!("Event not found: {:?}", id); // P1372
         HttpResponse::NotFound().finish()
     }
 }
@@ -112,8 +126,10 @@ async fn delete_event(id: web::Path<Uuid>, db: web::Data<EventDb>) -> impl Respo
     let mut events = db.lock().unwrap();
     if let Some(pos) = events.iter().position(|event| event.id == *id) {
         events.remove(pos);
+        info!("Deleted event: {:?}", id); // P1372
         HttpResponse::NoContent().finish()
     } else {
+        warn!("Event not found: {:?}", id); // P1372
         HttpResponse::NotFound().finish()
     }
 }
@@ -121,6 +137,7 @@ async fn delete_event(id: web::Path<Uuid>, db: web::Data<EventDb>) -> impl Respo
 #[get("/events")]
 async fn list_events(db: web::Data<EventDb>) -> impl Responder {
     let events = db.lock().unwrap();
+    info!("Listing all events"); // P1372
     HttpResponse::Ok().json(events.clone())
 }
 

--- a/services/web-ui/src/main.rs
+++ b/services/web-ui/src/main.rs
@@ -1,0 +1,153 @@
+use actix_web::{web, App, HttpServer, HttpResponse, Responder};
+use actix_web::middleware::Logger;
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Scan {
+    id: Uuid,
+    name: String,
+    target: String,
+    status: String,
+}
+
+type ScanDb = Mutex<Vec<Scan>>;
+
+#[post("/scans")]
+async fn create_scan(scan: web::Json<Scan>, db: web::Data<ScanDb>) -> impl Responder {
+    let mut scans = db.lock().unwrap();
+    let new_scan = Scan {
+        id: Uuid::new_v4(),
+        status: "created".to_string(),
+        ..scan.into_inner()
+    };
+    scans.push(new_scan.clone());
+    HttpResponse::Ok().json(new_scan)
+}
+
+#[get("/scans/{id}")]
+async fn get_scan(id: web::Path<Uuid>, db: web::Data<ScanDb>) -> impl Responder {
+    let scans = db.lock().unwrap();
+    if let Some(scan) = scans.iter().find(|&scan| scan.id == *id) {
+        HttpResponse::Ok().json(scan)
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}
+
+#[put("/scans/{id}")]
+async fn update_scan(id: web::Path<Uuid>, scan: web::Json<Scan>, db: web::Data<ScanDb>) -> impl Responder {
+    let mut scans = db.lock().unwrap();
+    if let Some(existing_scan) = scans.iter_mut().find(|scan| scan.id == *id) {
+        *existing_scan = scan.into_inner();
+        HttpResponse::Ok().json(existing_scan.clone())
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}
+
+#[delete("/scans/{id}")]
+async fn delete_scan(id: web::Path<Uuid>, db: web::Data<ScanDb>) -> impl Responder {
+    let mut scans = db.lock().unwrap();
+    if let Some(pos) = scans.iter().position(|scan| scan.id == *id) {
+        scans.remove(pos);
+        HttpResponse::NoContent().finish()
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}
+
+#[get("/scans")]
+async fn list_scans(db: web::Data<ScanDb>) -> impl Responder {
+    let scans = db.lock().unwrap();
+    HttpResponse::Ok().json(scans.clone())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Event {
+    id: Uuid,
+    scan_id: Uuid,
+    event_type: String,
+    data: String,
+    timestamp: u64,
+}
+
+type EventDb = Mutex<Vec<Event>>;
+
+#[post("/events")]
+async fn create_event(event: web::Json<Event>, db: web::Data<EventDb>) -> impl Responder {
+    let mut events = db.lock().unwrap();
+    let new_event = Event {
+        id: Uuid::new_v4(),
+        ..event.into_inner()
+    };
+    events.push(new_event.clone());
+    HttpResponse::Ok().json(new_event)
+}
+
+#[get("/events/{id}")]
+async fn get_event(id: web::Path<Uuid>, db: web::Data<EventDb>) -> impl Responder {
+    let events = db.lock().unwrap();
+    if let Some(event) = events.iter().find(|&event| event.id == *id) {
+        HttpResponse::Ok().json(event)
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}
+
+#[put("/events/{id}")]
+async fn update_event(id: web::Path<Uuid>, event: web::Json<Event>, db: web::Data<EventDb>) -> impl Responder {
+    let mut events = db.lock().unwrap();
+    if let Some(existing_event) = events.iter_mut().find(|event| event.id == *id) {
+        *existing_event = event.into_inner();
+        HttpResponse::Ok().json(existing_event.clone())
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}
+
+#[delete("/events/{id}")]
+async fn delete_event(id: web::Path<Uuid>, db: web::Data<EventDb>) -> impl Responder {
+    let mut events = db.lock().unwrap();
+    if let Some(pos) = events.iter().position(|event| event.id == *id) {
+        events.remove(pos);
+        HttpResponse::NoContent().finish()
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}
+
+#[get("/events")]
+async fn list_events(db: web::Data<EventDb>) -> impl Responder {
+    let events = db.lock().unwrap();
+    HttpResponse::Ok().json(events.clone())
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    let scan_db = web::Data::new(Mutex::new(Vec::<Scan>::new()));
+    let event_db = web::Data::new(Mutex::new(Vec::<Event>::new()));
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .app_data(scan_db.clone())
+            .app_data(event_db.clone())
+            .service(create_scan)
+            .service(get_scan)
+            .service(update_scan)
+            .service(delete_scan)
+            .service(list_scans)
+            .service(create_event)
+            .service(get_event)
+            .service(update_event)
+            .service(delete_event)
+            .service(list_events)
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}


### PR DESCRIPTION
Implement the web UI using Actix-web framework.

* **Scan Management**
  - Define `Scan` struct with fields: `id`, `name`, `target`, and `status`.
  - Create `ScanDb` type as a `Mutex` of `Vec<Scan>`.
  - Implement routes for creating, retrieving, updating, deleting, and listing scans.
  - Use `Uuid` for unique scan identifiers.

* **Event Handling**
  - Define `Event` struct with fields: `id`, `scan_id`, `event_type`, `data`, and `timestamp`.
  - Create `EventDb` type as a `Mutex` of `Vec<Event>`.
  - Implement routes for creating, retrieving, updating, deleting, and listing events.
  - Use `Uuid` for unique event identifiers.

* **Server Setup**
  - Initialize logger.
  - Create `scan_db` and `event_db` as shared data.
  - Set up Actix-web `HttpServer` with routes for scan and event management.
  - Bind server to `127.0.0.1:8080`.

